### PR TITLE
Onchain provider

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -49,7 +49,7 @@ type LightningClient interface {
 
 	// EstimateFees estimates the total fees for a batch of transactions that pay the given
 	// amounts to the passed addresses.
-	EstimateFees(ctx context.Context, txBatch map[string]int64) (btcutil.Amount, error)
+	EstimateFees(ctx context.Context, txBatch map[string]int64) (*lnrpc.EstimateFeeResponse, error)
 
 	// EstimateFeeToP2WSH estimates the total chain fees in satoshis to send
 	// the given amount to a single P2WSH output with the given target


### PR DESCRIPTION
Exposes some of the endpoints needed for btcproxy to move funds on chain, generate addresses, and estimate fees. 