### PR TITLE
[BTCP-50] change the block confirmation target

### DIFF
--- a/lightning_client.go
+++ b/lightning_client.go
@@ -4334,7 +4334,7 @@ func (s *lightningClient) EstimateFees(ctx context.Context, txBatch map[string]i
 		rpcCtx,
 		&lnrpc.EstimateFeeRequest{
 			AddrToAmount: txBatch,
-			TargetConf:   1, // confirm within x blocks
+			TargetConf:   2, // confirm within x blocks
 			MinConfs:     1, // use utxos with a minimum conf of x blocks
 		},
 	)

--- a/lightning_client.go
+++ b/lightning_client.go
@@ -1215,7 +1215,7 @@ type QueryRoutesRequest struct {
 	FeeLimitMsat lnwire.MilliSatoshi
 
 	// The time preference for this payment. Set to -1 to optimize for fees only, to 1 to optimize for reliability only
-	// or a value inbetween for a mix.
+	// or a value in between for a mix.
 	TimePref float64
 }
 

--- a/router_client.go
+++ b/router_client.go
@@ -281,7 +281,7 @@ type SendPaymentRequest struct {
 	PaymentAddr []byte
 
 	// The time preference for this payment. Set to -1 to optimize for fees only, to 1 to optimize for reliability only
-	// or a value inbetween for a mix.
+	// or a value in between for a mix.
 	TimePref float64
 }
 

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -300,14 +300,6 @@
                 }
             ]
         },
-        "/lnrpc.Lightning/EstimateFees": {
-            "permissions": [
-                {
-                    "entity": "onchain",
-                    "action": "read"
-                }
-            ]
-        },
         "/lnrpc.Lightning/ExportAllChannelBackups": {
             "permissions": [
                 {

--- a/testdata/permissions.json
+++ b/testdata/permissions.json
@@ -300,6 +300,14 @@
                 }
             ]
         },
+        "/lnrpc.Lightning/EstimateFees": {
+            "permissions": [
+                {
+                    "entity": "onchain",
+                    "action": "read"
+                }
+            ]
+        },
         "/lnrpc.Lightning/ExportAllChannelBackups": {
             "permissions": [
                 {


### PR DESCRIPTION
#### Pull Request Checklist

This pr modifies the number of block confirmation target. With the purpose of reduce the possibility of very high fee's.

- [ ] PR is opened against correct version branch.
- [ ] Version compatibility matrix in the README and minimal required version
      in `lnd_services.go` are updated.
- [ ] Update `macaroon_recipes.go` if your PR adds a new method that is called
  differently than the RPC method it invokes.

Locally tested:
I used the replace tag to redirect the lndclient version to the local one that was modified, then ran go mod tidy and tested.
![image](https://github.com/IBEXDWM/lndclient/assets/40869458/3805b9e1-913b-4dce-882a-379696c9ff43)
![image](https://github.com/IBEXDWM/lndclient/assets/40869458/49cdec57-d6da-452f-83fa-5af0ad0c74de)

